### PR TITLE
Replace tuist installation to build from sources via homebrew

### DIFF
--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -7,6 +7,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Install Homebrew
+        uses: Homebrew/actions/setup-homebrew@master
       - name: Install Tuist
         run: curl -Ls https://install.tuist.io | bash
       - name: Install dependencies

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -11,7 +11,9 @@ jobs:
       - name: Install Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install Tuist
-        run: curl -Ls https://install.tuist.io | bash
+        run: |
+          curl -o tuist.rb https://raw.githubusercontent.com/vanyauhalin/homebrew/main/Formula/tuist.rb
+          brew install --build-from-source tuist.rb
       - name: Install dependencies
         run: make install
       - name: Build project

--- a/.github/workflows/draft.yml
+++ b/.github/workflows/draft.yml
@@ -6,7 +6,8 @@ jobs:
   draft:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - name: Checkout
+        uses: actions/checkout@v3
       - name: Install Homebrew
         uses: Homebrew/actions/setup-homebrew@master
       - name: Install Tuist


### PR DESCRIPTION
- Add homebrew installation for the draft action
- Add the name for the checkout step in the draft action
- Replace tuist installation to build from sources via homebrew
