### PR TITLE
Make the target and resource URLs absolute by default

### DIFF
--- a/Fresco/Resource.swift
+++ b/Fresco/Resource.swift
@@ -38,6 +38,7 @@ public struct Resource {
   /// Returns `nil` if the resource at the provided url does not exist or is
   /// invalid.
   public init?(url: URL) {
+    let url = url.absoluteURL
     guard
       let data = try? Data(contentsOf: url),
       let image = NSImage(data: data),

--- a/Fresco/Target.swift
+++ b/Fresco/Target.swift
@@ -17,9 +17,7 @@ public struct Target {
   /// supported.
   public init?(path: String) {
     let url = URL(filePath2: path)
-    let path = url.path2()
     guard
-      FileManager.default.fileExists(atPath: path),
       let attributes = try? url.resourceValues(forKeys: Target.supported),
       attributes.isApplication == true
       || attributes.isDirectory == true

--- a/Fresco/Target.swift
+++ b/Fresco/Target.swift
@@ -16,7 +16,7 @@ public struct Target {
   /// Returns `nil` if the target at the provided path does not exist or is not
   /// supported.
   public init?(path: String) {
-    let url = URL(filePath2: path)
+    let url = URL(filePath2: path).absoluteURL
     guard
       let attributes = try? url.resourceValues(forKeys: Target.supported),
       [

--- a/Fresco/Target.swift
+++ b/Fresco/Target.swift
@@ -19,9 +19,12 @@ public struct Target {
     let url = URL(filePath2: path)
     guard
       let attributes = try? url.resourceValues(forKeys: Target.supported),
-      attributes.isApplication == true
-      || attributes.isDirectory == true
-      || attributes.isRegularFile == true
+      [
+        attributes.isApplication,
+        attributes.isDirectory,
+        attributes.isRegularFile
+      ]
+        .contains(true)
     else {
       return nil
     }


### PR DESCRIPTION
- Delete duplicate target existence check
- Make target support check more readable
- Make the target and resource URLs absolute by default
